### PR TITLE
Use an upsert in storeOrUpdate

### DIFF
--- a/lib/postgrestore.js
+++ b/lib/postgrestore.js
@@ -104,22 +104,7 @@ PostgreStore.prototype.storeOrUpdate = function(token, uid, msToLive, originUrl,
             return callback(err);
         }
 
-        self._client.query('INSERT INTO ' + self._table + '(uid,token, origin, ttl) VALUES($1, $2, $3, $4)',[uid, hashedToken, originUrl, (Date.now() + msToLive)], function(err) {
-            if(err){
-                self._client.query('UPDATE ' + self._table + ' SET token=$1, origin=$2, ttl=$3 WHERE uid=$4',[hashedToken, originUrl, (Date.now() + msToLive), uid], function(err) {
-                    if(err){
-                        callback(err);
-                    }
-                    else{
-                        callback();
-                    }
-                    //self._client.end();
-                });
-            }
-            else{
-                callback();
-            }
-        });
+        self._client.query('INSERT INTO ' + self._table + '(uid, token, origin, ttl) VALUES($1, $2, $3, $4) ON CONFLICT (uid) DO UPDATE SET token=$2, origin=$3, ttl=$4', [uid, hashedToken, originUrl, (Date.now() + msToLive)], callback);
     });
 };
 


### PR DESCRIPTION
This uses `ON CONFLICT DO UPDATE` instead of checking the error
and making a second query. This is faster (fewer round trips) and
also simpler (don't need to make sure the error is actually a
conflict -- the server does that for us).

Fixes #7