### PR TITLE
Use new pg.Pool() interface

### DIFF
--- a/lib/postgrestore.js
+++ b/lib/postgrestore.js
@@ -24,17 +24,19 @@ function PostgreStore(conString, options) {
 	this._options = options || {};
 	this._options.pgstore = this._options.pgstore || {};
 	this._table = this._options.pgstore.table || 'passwordless';
-    pg.defaults.poolSize = this._options.pgstore.pgPoolSize || 10;
+
+    this._client = new pg.Pool({
+        connectionString: conString,
+        max: this._options.pgstore.pgPoolSize || 10
+    });
 
     delete this._options.pgstore;
 
     var self = this;
-    pg.connect(conString, function(err, client, done) {
+    this._client.connect(function(err, client) {
         if(err) {
             throw new Error('Could not connect to Postgres database, with error : ' + err);
         }
-        self._client = client;
-        self._pgDone = done;
     });
 }
 
@@ -184,9 +186,7 @@ PostgreStore.prototype.length = function(callback) {
 };
 
 PostgreStore.prototype.disconnect = function() {
-    if(!this._pgDone) {
-        this._pgDone();
-    }
+    self._client.done();
 };
 
 function isNumber(n) {

--- a/test/postgrestore.js
+++ b/test/postgrestore.js
@@ -8,8 +8,6 @@ var PostgreStore = require('../');
 var TokenStore = require('passwordless-tokenstore');
 
 var pg = require('pg');
-var pgClient = null;
-var conString = 'postgres://postgres:password@localhost/postgres';
 
 var standardTests = require('passwordless-tokenstore-test');
 
@@ -17,26 +15,21 @@ function TokenStoreFactory() {
 	return new PostgreStore(conString);
 }
 
-var pgDoneCallback;
+var conString = 'postgres://localhost';
+var pgClient = new pg.Pool(conString);
+
+pgClient.connect(function (err) {
+	if (err) {
+		done(err);
+		throw new Error('Could not connect to Postgres database, with error : ' + err);
+	}
+});
 
 var beforeEachTest = function(done) {
-    if(!pgClient) {
-        pg.connect(conString, function(err, newClient, pgDone) {
-            if(err) {
-                done(err);
-                throw new Error('Could not connect to Postgres database, with error : ' + err);
-            }
-            pgClient = newClient;
-            done();
-            pgDoneCallback = pgDone;
-        });
-    }else{
-        done();
-    }
+	done();
 };
 
 var afterEachTest = function(done) {
-    pgDoneCallback();
     done();
 };
 
@@ -62,7 +55,12 @@ describe('Specific tests', function() {
 	});
 
 	it('should allow proper instantiation', function () {
-		expect(function() { TokenStoreFactory() }).to.not.throw;
+		expect(function () { TokenStoreFactory() }).to.not.throw;
+	});
+
+	it('should disconnect without errors', function () {
+		var store = TokenStoreFactory();
+		expect(function () { store.disconnect() }).to.not.throw;
 	});
 
 	it('should store tokens only in their hashed form', function(done) {


### PR DESCRIPTION
Using pg.Pool() ensures that the client is connected before trying
to execute any queries, so it simplifies our constructor and destructor
while also making the code safer.

This also gets rid of an annoying deprecation warning.

Fixes #8 