### PR TITLE
Only try to update if the insert error was a unique constraint violation

### DIFF
--- a/lib/postgrestore.js
+++ b/lib/postgrestore.js
@@ -113,17 +113,27 @@ PostgreStore.prototype.storeOrUpdate = function(token, uid, msToLive, originUrl,
             return callback(err);
         }
 
-        self._client.query('INSERT INTO ' + self._table + '(uid,token, origin, ttl) VALUES($1, $2, $3, $4)',[uid, hashedToken, originUrl, (Date.now() + msToLive)], function(err) {
+        self._client.query('INSERT INTO ' + self._table + '(uid,token, origin, ttl) VALUES($1, $2, $3, $4)', [uid, hashedToken, originUrl, (Date.now() + msToLive)], function (err) {
             if(err){
-                self._client.query('UPDATE ' + self._table + ' SET token=$1, origin=$2, ttl=$3 WHERE uid=$4',[hashedToken, originUrl, (Date.now() + msToLive), uid], function(err) {
-                    if(err){
-                        callback(err);
-                    }
-                    else{
-                        callback();
-                    }
-                    //self._client.end();
-                });
+                // 23505 is a unique constraint violation, so try to update in that case
+                // See: https://www.postgresql.org/docs/9.2/static/errcodes-appendix.html
+                if(err.code != 23505){
+                    callback(err);
+                }
+                else{
+                    self._client.query('UPDATE ' + self._table + ' SET token=$1, origin=$2, ttl=$3 WHERE uid=$4',[hashedToken, originUrl, (Date.now() + msToLive), uid], function(err, res) {
+                        if(err){
+                            callback(err);
+                        }
+                        else if(res.rowCount !== 1) {
+                            callback(new Error("TokenStore:storeOrUpdate tried to update the token for user " + uid + " but didn't update any rows"));
+                        }
+                        else{
+                            callback();
+                        }
+                        //self._client.end();
+                    });
+                }
             }
             else{
                 callback();


### PR DESCRIPTION
This fixes a problem I just ran into where I hadn't given my app the right permissions,
so it tried to do an insert and failed, then tried to do an update and didn't get an
error (but also didn't update any rows).

There are two levels of fixes:

 - Only try to do an update if the error was a unique constraint violation,
   since other errors should cause us to just stop immediately.
 - If we do an update and it doesn't actually update anything, return an error.